### PR TITLE
fix for latest NGINX helm chart

### DIFF
--- a/kubernetes_magnum/nginx_ingress.yaml
+++ b/kubernetes_magnum/nginx_ingress.yaml
@@ -4,7 +4,8 @@
 controller:
   name: controller
   image:
-    repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+    registry: quay.io
+    repository: kubernetes-ingress-controller/nginx-ingress-controller
     tag: "0.24.1"
     pullPolicy: IfNotPresent
     # www-data -> uid 33


### PR DESCRIPTION
stable/nginx-ingress has [added a controller.image.registry parameter](https://github.com/helm/charts/tree/master/stable/nginx-ingress) with a default of us.gcr.io causing the controller to error looking for an image at us.gcr.io/quay.io/.... Fix puts registry as quay.io and removes the prefix to the image to achieve the same effect as before the chart upgrade.