### PR TITLE
Patch cert-manager deployments; See #52

### DIFF
--- a/setup_https/deploymentPatch.sh
+++ b/setup_https/deploymentPatch.sh
@@ -1,0 +1,9 @@
+# Patch deployments to make cert-manager pods spawn in master node
+# See https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream/issues/52
+
+DEPLOYMENTS=( "cert-manager" "cert-manager-cainjector" "cert-manager-webhook" )
+
+for DEPLOYMENT in ${DEPLOYMENTS[@]}
+do
+        kubectl patch deployment -n cert-manager $DEPLOYMENT --patch-file ./deploymentPatch.yml
+done

--- a/setup_https/deploymentPatch.yml
+++ b/setup_https/deploymentPatch.yml
@@ -1,0 +1,10 @@
+# deploymentPatch.yml referenced in deploymentPatch.sh
+---
+spec:
+  template:
+    spec:
+      nodeSelector:
+        "node-role.kubernetes.io/master": ""
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"


### PR DESCRIPTION
See https://github.com/Unidata/science-gateway/tree/master/vms/jupyter#letsencrypt-versus-certificate-from-a-certificate-authority for our own docs on the steps taken to apply this patch.

Of course feel free to make suggestions on the names/locations of files, or anything else you find lacking.