### PR TITLE
Gateways 2023 tutorial

### DIFF
--- a/gateways2023/README.md
+++ b/gateways2023/README.md
@@ -1,0 +1,3 @@
+# Gateways 2023 tutorial
+
+* [Plan](plan.md)

--- a/gateways2023/plan.md
+++ b/gateways2023/plan.md
@@ -1,0 +1,34 @@
+# Plan for Gateways 2023 tutorial
+
+## Title
+
+Interactive distributed computing with Jupyter+Python+Dask on Jetstream for Science Gateways
+
+## Requirements
+
+Basic Python knowledge preferred, no previous knowledge of Dask or distributed computing required.
+
+## Before the workshop
+
+Deploy:
+* Kubernetes hopefully with Magnum, otherwise [with Kubespray](https://github.com/jetstream-cloud/js2docs/pull/46)
+* [Jupyterhub](https://www.zonca.dev/posts/2022-03-31-jetstream2_jupyterhub)
+* [Dask Gateway](https://www.zonca.dev/posts/2022-04-04-dask-gateway-jupyterhub)
+
+Update all the tutorials involved, if needed.
+
+Test all the material
+
+Day before the workshop
+* Scale up the deployment based on registered users
+
+## Workshop program
+
+* Users connect to the JupyterHub instance, something like `gw.jetstream-cloud.org`
+* Users login via Github (any Github account works no need to lock it down)
+* Show a flow-chart of the architecture of the whole system, explain that we have tutorials so that Gateways developers can deploy themselves, provide slide and webpage with all links
+* Familiarize with Dask locally in Jupyter
+* Connect to Dask Gateway
+* Run multiple distributed computations with Dask showing scaling and statistics
+* The material will be a subset of the Dask tutorial @zonca teaches at the [San Diego Summer Institute](https://github.com/sdsc/sdsc-summer-institute-2021/tree/main/2.1a_Python_for_HPC), executed on Jetstream instead of Expanse.
+* Save data to object storage in Zarr format, see <https://www.zonca.dev/posts/2022-04-04-zarr_jetstream2>, maybe also read in parallel with Dask


### PR DESCRIPTION
Planning to propose a tutorial for [Gateways 2023](https://sciencegateways.org/gateways2023-cfp#Tutorials)

The idea is to propose a tutorial where we show off capabilities of Jetstream suitable to Science Gateways,
but we don't actually show users how to deploy infrastructure, that is just good for a tiny subset of system admins.

We show them from the user's perspective how you could provide a JupyterHub deployment on Jetstream that
not only does interactive computing, but also distributed data processing via dask.