### PR TITLE
JupyterHub Helm Chart v4.2.0

### DIFF
--- a/install_jhub.sh
+++ b/install_jhub.sh
@@ -4,6 +4,6 @@ NAMESPACE=jhub
 helm upgrade --install $RELEASE jupyterhub/jupyterhub \
       --namespace $NAMESPACE  \
       --create-namespace \
-      --version 3.0.3 \
+      --version 4.2.0 \
       --debug \
       --values config_standard_storage.yaml --values secrets.yaml


### PR DESCRIPTION
Update the helm chart version from 3.0.3 (Aug, 2023; JHub v4.0.2) to 4.2.0 (Apr 2025; JHub v5.3.0).

While JHub 5.3.0 hasn't been tested by @julienchastang nor myself, we've been using helm chart version 4.1.0 (JHub 5.2.1) on a development cluster since the start of the year without any problems:

```
$ helm list -n jhub
NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
jhub    jhub            166             2025-06-30 03:55:38.913853511 +0000 UTC deployed        jupyterhub-4.1.0        5.2.1
```

If you'd like to use the tested helm chart version instead, feel free to edit this PR.

Thanks!