### PR TITLE
Security release: bump helm chart to v4.3.3

### DIFF
--- a/install_jhub.sh
+++ b/install_jhub.sh
@@ -4,6 +4,6 @@ NAMESPACE=jhub
 helm upgrade --install $RELEASE jupyterhub/jupyterhub \
       --namespace $NAMESPACE  \
       --create-namespace \
-      --version 4.3.1 \
+      --version 4.3.3 \
       --debug \
       --values config_standard_storage.yaml --values secrets.yaml


### PR DESCRIPTION
This helm chart release bumps JupyterHub to version 5.4.4, which addresses some vulnerabilities. See the announcement:

https://discourse.jupyter.org/t/ann-security-releases-of-jupyterhub-auth0-lti-authenticators/38480